### PR TITLE
Improvements to provider type selection

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -125,6 +125,41 @@ router.post('/sprint-13/tlevels-checkanswers', function (req, res) {
 
     
 
+// SPRINT 16 
+
+
+    router.get('/sprint-16/tribal-provider-details', function (req, res) {
+        if (req.session.data['provider-type-backup']){
+            req.session.data['provider-type'] = req.session.data['provider-type-backup']
+        }
+        res.render('sprint-16/tribal-provider-details');
+    })
+
+
+    router.post('/sprint-16/tribal-provider-type', function (req, res) {
+        if (!req.session.data['provider-type']){
+            req.session.data['provider-type'] = "None";
+        } else if (req.session.data['provider-type'].includes("T Levels")){
+            res.redirect('/sprint-16/tribal-provider-tlevels');
+        }
+        req.session.data['provider-type-backup'] = req.session.data['provider-type'] //set fallback provider typ eif incomplete journey
+        res.redirect('/sprint-16/tribal-provider-details');
+    })
+    router.post('/sprint-16/tribal-provider-tlevels', function (req, res) {
+        if (!req.session.data['provider-type-tlevels']){
+            res.redirect('/sprint-16/tribal-provider-tlevels-error');
+        }
+        req.session.data['provider-type-backup'] = req.session.data['provider-type'] //set fallback provider typ eif incomplete journey
+        res.redirect('/sprint-16/tribal-provider-details');
+    })
+    router.post('/sprint-16/tribal-provider-tlevels-error', function (req, res) {
+        if (!req.session.data['provider-type-tlevels']){
+            res.redirect('/sprint-16/tribal-provider-tlevels-error');
+        }
+        req.session.data['provider-type-backup'] = req.session.data['provider-type'] //set fallback provider typ eif incomplete journey
+        res.redirect('/sprint-16/tribal-provider-details');
+    })
+
 
 
 module.exports = router

--- a/app/views/includes/header-sprint16.html
+++ b/app/views/includes/header-sprint16.html
@@ -1,0 +1,47 @@
+<header class="govuk-header " role="banner" data-module="govuk-header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__content" style="width: 80%;">
+      <a href="#" class="govuk-header__link govuk-header__link--service-name">
+        Publish to the course directory
+      </a>
+      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav>
+        <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+            <a class="govuk-header__link" href="homescreen">
+              Home
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Courses
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Apprenticeships
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              T Levels
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Locations
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Bulk upload
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div class="header__signin">
+      <a class="header__link govuk-header__link" href="#">Sign out</a>
+    </div>
+  </div>
+</header>

--- a/app/views/includes/header-tribal-sprint16.html
+++ b/app/views/includes/header-tribal-sprint16.html
@@ -1,0 +1,42 @@
+<header class="govuk-header " role="banner" data-module="govuk-header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__content" style="width: auto;">
+      <a href="#" class="govuk-header__link govuk-header__link--service-name">
+        Publish to the course directory
+      </a>
+      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav>
+        <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="javascript:preventDefault();">
+              Helpdesk dashboard
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="javascript:preventDefault();">
+              Quality assurance
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+            <a class="govuk-header__link" href="javascript:preventDefault();">
+              Search providers
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="javascript:preventDefault();">
+              Manage users
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="javascript:preventDefault();">
+              Migration reports
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div class="header__signin">
+      <a class="header__link govuk-header__link" href="#">Sign out</a>
+    </div>
+  </div>
+</header>

--- a/app/views/includes/tribal-mininav-sprint16.html
+++ b/app/views/includes/tribal-mininav-sprint16.html
@@ -1,0 +1,53 @@
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="cd-card cd-card-mininav govuk-!-margin-top-5 govuk-!-margin-bottom-0">
+      <p class="govuk-body">PRESIDENCY LONDON COLLEGE LIMITED</p>
+      <nav>
+        <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+            <a class="govuk-header__link" href="tribal-homescreen">
+              Home
+            </a>
+          </li>
+
+          {% if data[usewhichdata] %}
+
+          {% if data[usewhichdata].includes("F.E.") %}
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Courses
+            </a>
+          </li>
+          {% endif %}
+          {% if data[usewhichdata].includes("Apprenticeships") %}
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Apprenticeships
+            </a>
+          </li>
+          {% endif %}
+          {% if data[usewhichdata].includes("T Levels") %}
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              T Levels
+            </a>
+          </li>
+          {% endif %}
+          {% endif %}
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Locations
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="#">
+              Bulk upload
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -27,18 +27,21 @@
             </span>
           </h2>
           <div class="govuk-accordion__section-summary govuk-body" id="accordion-with-summary-sections-summary-12">
-            Handling lots of venues
+            Managing provider type and T Levels details with more than 10 venues
           </div>
         </div>
         <div id="accordion-default-content-13" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-13">
 
           <ul class="govuk-list">
+            <li><b>Managing provider type and associated T Levels</b></li>
+            <li><a class="govuk-link" href="sprint-16/tribal-provider-details">Provider details (Tribal screen)</a></li>
+            <li>&nbsp;</li>
             <li><b>Handling more than 10 venues</b></li>
             <li><a class="govuk-link" href="sprint-16/many-venues-tlevel-details">T Level details</a></li>
-            <li>&nbsp;</li>
+            <!--li>&nbsp;</li>
             <li><b>Unauthorised access</b></li>
             <li><a class="govuk-link" href="sprint-16/shutter-unauthorised">Shutter page - unauthorised access</a></li>
-            <li>&nbsp;</li>
+            <li>&nbsp;</li-->
           </ul>
 
         </div>

--- a/app/views/layout-sprint16.html
+++ b/app/views/layout-sprint16.html
@@ -1,0 +1,92 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
+
+  {% if data['provider-type-backup'] != data['provider-type'] %}
+    {% set usewhichdata = "provider-type-backup" %}
+  {% else %}
+    {% set usewhichdata = "provider-type" %}
+  {% endif %}
+
+{% block head %}
+  {% include "includes/head.html" %}
+{% endblock %}
+
+{% block pageTitle %}
+  GOV.UK Prototype Kit
+{% endblock %}
+
+{% block header %}
+  {% include "includes/cookie-banner.html" %}
+  {# Set serviceName in config.js. #}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: serviceName,
+    serviceUrl: "/",
+    containerClasses: "govuk-width-container"
+  }) }}
+{% endblock %}
+
+{% if useAutoStoreData %}
+  {% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: "https://govuk-prototype-kit.herokuapp.com/",
+            text: "GOV.UK Prototype Kit " + releaseVersion
+          },
+          {
+            href: "../new-provider/cookie-settings",
+            text: "Cookies"
+          },
+          {
+            href: "/prototype-admin/clear-data",
+            text: "Clear data"
+          },
+          {
+            href: "../index",
+            text: "Prototype page"
+          }
+        ]
+      }
+    }) }}
+  {% endblock %}
+
+{% endif %}
+
+{% block bodyEnd %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+
+{% endblock %}

--- a/app/views/sprint-16/location-add-select.html
+++ b/app/views/sprint-16/location-add-select.html
@@ -1,0 +1,84 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Provider home screen - All provider types
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header-sprint16.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'This is a new service - your <a href=javascript:preventDefault();#" class="govuk-link">feedback</a> will help us to improve it.'
+}) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Add location
+      </h1>
+
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Postcode</h2>
+      <p class="govuk-body">SW1A 1AA <a href="javascript:preventDefault();" class="govuk-!-margin-left-5">Change<span class="govuk-visually-hidden"> postcode</span></a></p>
+
+      {{ govukSelect({
+        id: "location-add-postcode-select",
+        name: "location-add-postcode-select",
+        label: {
+          classes: "govuk-label--m",
+          text: "Select an address"
+        },
+        items: [
+          {
+            value: "",
+            text: "1 address found"
+          },
+          {
+            value: "",
+            text: "Buckingham Palace, LONDON SW1A 1AA"
+          }
+        ]
+      }) }}
+
+      <p class="govuk-body"><a href="javascript:preventDefault();">I can't find my  address in the list</a></p>
+
+      {{ govukButton({
+        href: "location-add-details",
+        text: "Continue"
+      }) }}
+      
+
+<!--
+      {{ govukCharacterCount({
+        name: "location-name",
+        id: "location-name",
+        maxlength: 255,
+        rows: 1,
+        label: {
+          text: "Location name"
+        }
+      }) }}
+-->
+      
+    </div>
+    <div class="govuk-grid-column-one-third">
+      
+    </div>
+  </div>
+  
+
+
+  <!-- End of content -->
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->

--- a/app/views/sprint-16/location-add.html
+++ b/app/views/sprint-16/location-add.html
@@ -1,0 +1,71 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Provider home screen - All provider types
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header-sprint14.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'This is a new service - your <a href=javascript:preventDefault();#" class="govuk-link">feedback</a> will help us to improve it.'
+}) }}
+
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Add location
+      </h1>
+
+      {{ govukInput({
+        id: "location-add-postcode",
+        name: "location-add-postcode",
+        classes: "govuk-!-width-one-quarter",
+        label: {
+          classes: "govuk-label--m",
+          text: "Postcode"
+        },
+        value: "SW1A 1AA"
+      }) }}
+
+      {{ govukButton({
+        href: "location-add-select",
+        text: "Find address"
+      }) }}
+      
+
+<!--
+      {{ govukCharacterCount({
+        name: "location-name",
+        id: "location-name",
+        maxlength: 255,
+        rows: 1,
+        label: {
+          text: "Location name"
+        }
+      }) }}
+-->
+      
+    </div>
+    <div class="govuk-grid-column-one-third">
+      
+    </div>
+  </div>
+  
+
+
+  <!-- End of content -->
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->

--- a/app/views/sprint-16/tribal-provider-details.html
+++ b/app/views/sprint-16/tribal-provider-details.html
@@ -1,0 +1,237 @@
+{% extends "layout-sprint16.html" %}
+
+{% block pageTitle %}
+  Provider details FE only
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header-tribal-sprint16.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+  {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+  <!-- Provider navigation -->
+    {% include "includes/tribal-mininav-sprint16.html" %}
+  <!--  -->
+
+  {{ govukBackLink({
+    text: "Back to home screen",
+    href: "#"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+
+<!-- content start -->
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">PRESIDENCY LONDON COLLEGE LIMITED</h1>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Course directory status
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Active
+        </dd>
+        <dd class="govuk-summary-list__actions">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          UKPRN
+        </dt>
+        <dd class="govuk-summary-list__value">
+          10035735
+        </dd>
+        <dd class="govuk-summary-list__actions">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Trading name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Presidency London College
+        </dd>
+        <dd class="govuk-summary-list__actions">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Display name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data["provider-displayname"] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="tribal-provider-displayname">
+            Change<span class="govuk-visually-hidden"> display name</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Provider type
+        </dt>
+        <dd class="govuk-summary-list__value">
+
+          <ul class="govuk-list">
+          {% if data['provider-type'] %}
+
+            {% if data['provider-type-backup'] != data['provider-type'] %}
+              {% for item in data['provider-type-backup'] %}
+                <li>{{ item }}</li>
+              {% endfor %}
+            {% else %}
+              {% for item in data['provider-type'] %}
+                <li>{{ item }}</li>
+              {% endfor %}
+            {% endif %}
+
+<!--
+            {% set typecount = data['provider-type'] | length %}
+
+            {% set loopcount = 0 %}
+            {% for item in data['provider-type'] %}
+              {% set loopcount = loopcount + 1 %}
+              {{ item }}{% if typecount == 2 and loopcount == 1 %} and {% endif %}{% if typecount == 3 and loopcount == 1 %}, {% endif %}
+              {% if typecount == 3 and loopcount == 2 %}and{% endif %}
+            {% endfor %}
+      
+-->
+            </ul>
+          
+          {% else %}
+
+            <li>None</li>
+            
+          {% endif %}
+          </ul>
+          
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="tribal-provider-type">
+            Change<span class="govuk-visually-hidden"> provider type</span>
+          </a>
+        </dd>
+      </div>
+
+
+      {% if (data["provider-type-tlevels"]) and (data[usewhichdata].includes("T Levels")) %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            T Levels provided
+          </dt>
+          <dd class="govuk-summary-list__value">
+
+            <ul class="govuk-list">
+              {% for item in data['provider-type-tlevels'] %}
+                <li>{{ item }}</li>
+              {% endfor %}
+            </ul>
+
+            <!--
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  {{ data['provider-type-tlevels'] | length }} T Level{% if data['provider-type-tlevels'] | length > 1 %}s{% endif %} provided
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                {% for item in data['provider-type-tlevels'] %}
+                <p class="govuk-body">{{ item }}</p>
+                {% endfor %}
+              </div>
+            </details>
+            -->
+
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="tribal-provider-tlevels">
+              Change<span class="govuk-visually-hidden"> provider T Levels</span>
+            </a>
+          </dd>
+        </div>
+      {% endif %}
+      
+      {% if data[usewhichdata] and ('Apprenticeships' in data[usewhichdata]) %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Provider information
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data["provider-info"] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="tribal-provider-information">
+              Change<span class="govuk-visually-hidden"> provider information</span>
+            </a>
+          </dd>
+        </div>
+      {% endif %}
+
+    </dl>
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Help with your provider details
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+        <h3 class="govuk-heading-s">UKPRN</h3>
+        <p class="govuk-body">A unique number allocated to providers by the UKRLP verification team, after successful UKRLP registration.</p>
+        <h3 class="govuk-heading-s">Trading name</h3>
+        <p class="govuk-body">The name your organisation trades under if it is different to the organisation name.<p>
+        Trading names can be added when registering with UKRLP or after registration. Sign in to the <a href="https://www.ukrlp.co.uk/ukrlp/ukrlp.login" target="_blank">UK Register of Learning Providers (opens in a new window or tab)</a> to add or edit your trading name.</p>
+        <!--h3 class="govuk-heading-s">Display name</h3>
+        <p class="govuk-body">The name displayed to learners who can view and search for learning opportunities on the National Careers Service, Find a course.</p-->
+        </div>
+    </details>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contact details</h2>
+    <div class="govuk-related-items">
+
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-0">Website</h3>
+    <p class="govuk-body-s govuk-!-margin-bottom-3"><a href="http://www.presidencylondon.co.uk" target="_blank">http://www.presidencylondon.co.uk</a></p>
+
+    <!--h3 class="govuk-heading-m govuk-!-margin-bottom-0">Contact name</h3>
+    <p class="govuk-body-s govuk-!-margin-bottom-3">A Razaq Mohammed</p-->
+
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-0">Email</h3>
+    <p class="govuk-body-s govuk-!-margin-bottom-3"><a href="mailto:info@presidencylondon.co.uk">info@presidencylondon.co.uk</a></p>
+
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-0">Telephone</h3>
+    <p class="govuk-body-s govuk-!-margin-bottom-3">0203 7846005</p>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <p class="govuk-body-s govuk-!-margin-bottom-3">
+      <a href="https://www.ukrlp.co.uk/ukrlp/ukrlp.login" target="_blank">Update your primary contact details on UKRLP (opens in a new window or tab)</a>
+    </p>
+    <p class="govuk-body-s govuk-!-margin-bottom-3">Your contact details are displayed to learners on the National Careers Service and employers on Find an apprenticeship training.</p>
+  </div>
+
+
+</div>
+  <!-- End of content -->
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->

--- a/app/views/sprint-16/tribal-provider-tlevels-error.html
+++ b/app/views/sprint-16/tribal-provider-tlevels-error.html
@@ -1,0 +1,102 @@
+{% extends "layout-sprint16.html" %}
+
+{% block pageTitle %}
+  Provider type settings
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header-tribal-sprint16.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+  {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+  <!-- Provider navigation -->
+    {% include "includes/tribal-mininav-sprint16.html" %}
+  <!--  -->
+
+  {{ govukBackLink({
+    text: "Back to home screen",
+    href: "#"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+
+<!-- content start -->
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="" method="post" class="form">
+    
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: [
+        {
+          text: "Select the T Levels this provider can offer",
+          href: "#provider-type-tlevels"
+        }
+      ]
+    }) }}
+
+
+      {{ govukCheckboxes({
+        idPrefix: "provider-type-tlevels",
+        name: "provider-type-tlevels",
+        errorMessage: {
+          text: "Select the T Levels this provider can offer"
+        },
+        fieldset: {
+          legend: {
+            text: "T Levels provided",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            value: "Design, Surveying and Planning for Construction",
+            text: "Design, Surveying and Planning for Construction",
+            checked: checked("provider-type-tlevels", "Design, Surveying and Planning for Construction")
+          },
+          {
+            value: "Digital Production, Design and Development",
+            text: "Digital Production, Design and Development",
+            checked: checked("provider-type-tlevels", "Digital Production, Design and Development")
+          },
+          {
+            value: "Education and Childcare",
+            text: "Education and Childcare",
+            checked: checked("provider-type-tlevels", "Education and Childcare")
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    
+    </form>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+  </div>
+
+
+</div>
+  <!-- End of content -->
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->

--- a/app/views/sprint-16/tribal-provider-tlevels.html
+++ b/app/views/sprint-16/tribal-provider-tlevels.html
@@ -1,0 +1,88 @@
+{% extends "layout-sprint16.html" %}
+
+{% block pageTitle %}
+  Provider type settings
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header-tribal-sprint16.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+  {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+  <!-- Provider navigation -->
+    {% include "includes/tribal-mininav-sprint16.html" %}
+  <!--  -->
+
+  {{ govukBackLink({
+    text: "Back to home screen",
+    href: "#"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+
+<!-- content start -->
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="" method="post" class="form">
+
+      {{ govukCheckboxes({
+        idPrefix: "provider-type-tlevels",
+        name: "provider-type-tlevels",
+        fieldset: {
+          legend: {
+            text: "T Levels provided",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            value: "Design, Surveying and Planning for Construction",
+            text: "Design, Surveying and Planning for Construction",
+            checked: checked("provider-type-tlevels", "Design, Surveying and Planning for Construction")
+          },
+          {
+            value: "Digital Production, Design and Development",
+            text: "Digital Production, Design and Development",
+            checked: checked("provider-type-tlevels", "Digital Production, Design and Development")
+          },
+          {
+            value: "Education and Childcare",
+            text: "Education and Childcare",
+            checked: checked("provider-type-tlevels", "Education and Childcare")
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    
+    </form>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+  </div>
+
+
+</div>
+  <!-- End of content -->
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->

--- a/app/views/sprint-16/tribal-provider-type.html
+++ b/app/views/sprint-16/tribal-provider-type.html
@@ -1,0 +1,93 @@
+{% extends "layout-sprint16.html" %}
+
+{% block pageTitle %}
+  Provider type settings
+{% endblock %}
+
+{% block header %}
+  {% include "includes/header-tribal-sprint16.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+  }) }}
+
+  {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+  <!-- Provider navigation -->
+    {% include "includes/tribal-mininav-sprint16.html" %}
+  <!--  -->
+
+  {{ govukBackLink({
+    text: "Back to home screen",
+    href: "#"
+  }) }}
+
+{% endblock %}
+
+{% block content %}
+
+
+<!-- content start -->
+<div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="" method="post" class="form">
+
+      {{ govukCheckboxes({
+        idPrefix: "provider-type",
+        name: "provider-type",
+        fieldset: {
+          legend: {
+            text: "Provider type",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            checked: true,
+            value: "F.E.",
+            text: "F.E.",
+            checked: checked("provider-type", "F.E.")
+          },
+          {
+            checked: true,
+            value: "Apprenticeships",
+            text: "Apprenticeships",
+            checked: checked("provider-type", "Apprenticeships")
+          },
+          {
+            value: "T Levels",
+            text: "T Levels",
+            checked: checked("provider-type", "T Levels"),
+            conditional: {
+              html: tlevelHtml
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    
+    </form>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+  </div>
+
+
+</div>
+  <!-- End of content -->
+{% endblock %}
+
+<!-- DO NOT enter page content after the above block -->


### PR DESCRIPTION
Handles selection of T Levels and how  that is commited following the choice of available T Levels for the provider. Works in a way that replicates what real world interaction should be. This incorporates the selection of T Levels for provider type, and then no selection of associated T Levels and returning to the provider details page.

Mini provider navigation updates according to selected provider types.

Main nav 'Home' link updated to 'Halpdesk dashboard'